### PR TITLE
chore: ignore local utilities directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# Local utility scripts — not for version control
+/utilities/


### PR DESCRIPTION
## Summary
- Adds `/utilities/` to `.gitignore` so local-only scripts (e.g. CF Pages deployment cleanup) are never accidentally committed or pushed.

## Test plan
- [x] CI passes
- [x] Squash and merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)