### PR TITLE
fix: add x-axis labels and axis titles to distribution histogram

### DIFF
--- a/src/app/shared/stats-explorer/stats-explorer.component.ts
+++ b/src/app/shared/stats-explorer/stats-explorer.component.ts
@@ -177,9 +177,32 @@ export class StatsExplorerComponent implements AfterViewInit, OnDestroy {
           },
         },
         scales: {
-          x: { display: false },
+          x: {
+            display: true,
+            title: {
+              display: true,
+              text: 'Value',
+              color: '#aaa',
+            },
+            ticks: {
+              color: '#aaa',
+              maxTicksLimit: 8,
+              maxRotation: 0,
+              callback: (_val, index) => {
+                const label = this.chart?.data.labels?.[index]
+                if (typeof label !== 'string') return ''
+                return label.split('–')[0]
+              },
+            },
+            grid: { display: false },
+          },
           y: {
             beginAtZero: true,
+            title: {
+              display: true,
+              text: 'Frequency',
+              color: '#aaa',
+            },
             ticks: { color: '#aaa' },
             grid: { color: 'rgba(255,255,255,0.05)' },
           },


### PR DESCRIPTION
## Summary
- Enables x-axis on the histogram (was `display: false`)
- Shows up to 8 evenly spaced bin value labels along the x-axis
- Adds axis titles: **Value** (x) and **Frequency** (y)

## Test plan
- [x] Normal distribution shows x-axis labels centred around 0
- [x] Exponential distribution shows labels starting from 0
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)