### PR TITLE
feat: add profile page with auth guard

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -3,7 +3,9 @@ import { AboutComponent } from './pages/about/about.component'
 import { DashboardComponent } from './pages/dashboard/dashboard.component'
 import { AuthComponent } from './pages/auth/auth.component'
 import { ProjectComponent } from './pages/project/project.component'
+import { ProfileComponent } from './pages/profile/profile.component'
 import { PageNotFoundComponent } from './pages/page-not-found/page-not-found.component'
+import { authGuard } from './guards/auth.guard'
 
 export const routes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' },
@@ -12,5 +14,6 @@ export const routes: Routes = [
   { path: 'login', component: AuthComponent },
   { path: 'register', component: AuthComponent },
   { path: 'project', component: ProjectComponent },
+  { path: 'profile', component: ProfileComponent, canActivate: [authGuard] },
   { path: '**', component: PageNotFoundComponent },
 ]

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -1,0 +1,22 @@
+import { inject } from '@angular/core'
+import { CanActivateFn, Router } from '@angular/router'
+import { AuthService } from '../pages/auth/auth.service'
+import { map, take } from 'rxjs/operators'
+
+/**
+ * Prevents navigation to authenticated routes unless a valid session token
+ * exists in AuthService. Redirects unauthenticated users to /login.
+ *
+ * Note: This is a client-side convenience guard only. Actual enforcement
+ * happens at the API layer — every /user request requires a valid Bearer
+ * token and the server returns the requesting user's data only.
+ */
+export const authGuard: CanActivateFn = () => {
+  const authService = inject(AuthService)
+  const router = inject(Router)
+
+  return authService.getAuthStatus().pipe(
+    take(1),
+    map((isAuth) => (isAuth ? true : router.createUrlTree(['/login'])))
+  )
+}

--- a/src/app/pages/profile/profile.component.html
+++ b/src/app/pages/profile/profile.component.html
@@ -1,0 +1,148 @@
+<section class="profile-page">
+  <div class="page-container">
+    <!-- Loading -->
+    <div *ngIf="loadingProfile" class="loading-state">
+      <mat-spinner diameter="48"></mat-spinner>
+      <p class="loading-text">Loading your profile...</p>
+    </div>
+
+    <!-- Content -->
+    <div *ngIf="!loadingProfile && profile" class="profile-content">
+      <!-- Hero / Avatar -->
+      <div class="profile-hero">
+        <div class="avatar-ring">
+          <div class="avatar">{{ initials }}</div>
+        </div>
+        <h1 class="profile-name">{{ fullName }}</h1>
+        <span class="profile-username">&#64;{{ profile.username }}</span>
+        <span class="role-badge">{{ profile.role }}</span>
+      </div>
+
+      <!-- Cards -->
+      <div class="cards-grid">
+        <!-- Account details (read-only) -->
+        <div class="card glass">
+          <h2 class="card-title">
+            <mat-icon>person_outline</mat-icon>
+            Account Details
+          </h2>
+
+          <div class="detail-row">
+            <span class="detail-label">First name</span>
+            <span class="detail-value">{{ profile.firstname }}</span>
+          </div>
+          <div class="detail-row">
+            <span class="detail-label">Last name</span>
+            <span class="detail-value">{{ profile.lastname }}</span>
+          </div>
+          <div class="detail-row">
+            <span class="detail-label">Email</span>
+            <span class="detail-value">{{ profile.email }}</span>
+          </div>
+          <div class="detail-row">
+            <span class="detail-label">Username</span>
+            <span class="detail-value">{{ profile.username }}</span>
+          </div>
+
+          <div class="card-footer">
+            <button class="btn-danger" (click)="onLogout()">
+              <mat-icon>logout</mat-icon>
+              Sign out
+            </button>
+          </div>
+        </div>
+
+        <!-- Change password -->
+        <div class="card glass">
+          <h2 class="card-title">
+            <mat-icon>lock_outline</mat-icon>
+            Change Password
+          </h2>
+
+          <form (ngSubmit)="onChangePassword()" #pwForm="ngForm" novalidate>
+            <div class="field-group">
+              <label for="currentPassword">Current password</label>
+              <div class="input-wrapper">
+                <input
+                  id="currentPassword"
+                  name="currentPassword"
+                  [type]="showCurrentPassword ? 'text' : 'password'"
+                  [(ngModel)]="passwordForm.currentPassword"
+                  required
+                  placeholder="Enter current password"
+                  autocomplete="current-password"
+                />
+                <button
+                  type="button"
+                  class="visibility-btn"
+                  (click)="showCurrentPassword = !showCurrentPassword"
+                  [attr.aria-label]="showCurrentPassword ? 'Hide password' : 'Show password'"
+                >
+                  <mat-icon>{{ showCurrentPassword ? 'visibility_off' : 'visibility' }}</mat-icon>
+                </button>
+              </div>
+            </div>
+
+            <div class="field-group">
+              <label for="newPassword">New password</label>
+              <div class="input-wrapper">
+                <input
+                  id="newPassword"
+                  name="newPassword"
+                  [type]="showNewPassword ? 'text' : 'password'"
+                  [(ngModel)]="passwordForm.newPassword"
+                  required
+                  minlength="8"
+                  placeholder="At least 8 characters"
+                  autocomplete="new-password"
+                />
+                <button
+                  type="button"
+                  class="visibility-btn"
+                  (click)="showNewPassword = !showNewPassword"
+                  [attr.aria-label]="showNewPassword ? 'Hide password' : 'Show password'"
+                >
+                  <mat-icon>{{ showNewPassword ? 'visibility_off' : 'visibility' }}</mat-icon>
+                </button>
+              </div>
+            </div>
+
+            <div class="field-group">
+              <label for="confirmPassword">Confirm new password</label>
+              <div class="input-wrapper">
+                <input
+                  id="confirmPassword"
+                  name="confirmationPassword"
+                  [type]="showConfirmPassword ? 'text' : 'password'"
+                  [(ngModel)]="passwordForm.confirmationPassword"
+                  required
+                  placeholder="Re-enter new password"
+                  autocomplete="new-password"
+                />
+                <button
+                  type="button"
+                  class="visibility-btn"
+                  (click)="showConfirmPassword = !showConfirmPassword"
+                  [attr.aria-label]="showConfirmPassword ? 'Hide password' : 'Show password'"
+                >
+                  <mat-icon>{{ showConfirmPassword ? 'visibility_off' : 'visibility' }}</mat-icon>
+                </button>
+              </div>
+            </div>
+
+            <button
+              type="submit"
+              class="btn-primary"
+              [disabled]="changingPassword || !pwForm.valid"
+            >
+              <mat-icon>{{
+                changingPassword ? 'hourglass_empty' : 'check_circle_outline'
+              }}</mat-icon>
+              {{ changingPassword ? 'Updating...' : 'Update Password' }}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/app/pages/profile/profile.component.scss
+++ b/src/app/pages/profile/profile.component.scss
@@ -1,0 +1,278 @@
+.profile-page {
+  background: var(--bg-primary);
+  min-height: 100vh;
+  padding: 60px 24px 80px;
+}
+
+.page-container {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+// ── Loading ────────────────────────────────────────────────────
+.loading-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 120px 0;
+  gap: 24px;
+
+  .loading-text {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+  }
+}
+
+// ── Hero ───────────────────────────────────────────────────────
+.profile-hero {
+  text-align: center;
+  margin-bottom: 48px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.avatar-ring {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  background: var(--accent-gradient);
+  padding: 3px;
+  margin-bottom: 4px;
+}
+
+.avatar {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Outfit', sans-serif;
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--accent-gold);
+  letter-spacing: 0.02em;
+}
+
+.profile-name {
+  font-family: 'Outfit', sans-serif;
+  font-size: clamp(1.6rem, 4vw, 2.2rem);
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.profile-username {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.role-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 16px;
+  border-radius: 100px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: var(--accent-gold-dim);
+  color: var(--accent-gold);
+  border: 1px solid var(--border-accent);
+}
+
+// ── Cards layout ───────────────────────────────────────────────
+.cards-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  align-items: start;
+}
+
+.card {
+  padding: 32px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-subtle);
+}
+
+.card-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: 'Outfit', sans-serif;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 28px;
+
+  mat-icon {
+    color: var(--accent-gold);
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+  }
+}
+
+// ── Account detail rows ────────────────────────────────────────
+.detail-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--border-subtle);
+
+  &:last-of-type {
+    border-bottom: none;
+  }
+}
+
+.detail-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.detail-value {
+  font-size: 0.97rem;
+  color: var(--text-primary);
+}
+
+.card-footer {
+  margin-top: 28px;
+  padding-top: 20px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+// ── Password form ──────────────────────────────────────────────
+.field-group {
+  margin-bottom: 20px;
+
+  label {
+    display: block;
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--text-muted);
+    margin-bottom: 8px;
+  }
+}
+
+.input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+
+  input {
+    width: 100%;
+    padding: 12px 44px 12px 16px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    font-family: inherit;
+    transition: border-color var(--transition-fast);
+    box-sizing: border-box;
+
+    &::placeholder {
+      color: var(--text-muted);
+    }
+
+    &:focus {
+      outline: none;
+      border-color: var(--accent-gold);
+    }
+  }
+}
+
+.visibility-btn {
+  position: absolute;
+  right: 10px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  transition: color var(--transition-fast);
+
+  &:hover {
+    color: var(--accent-gold);
+  }
+
+  mat-icon {
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+  }
+}
+
+// ── Buttons ────────────────────────────────────────────────────
+.btn-primary,
+.btn-danger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 28px;
+  border-radius: var(--radius-md);
+  font-family: 'Inter', sans-serif;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: all var(--transition-fast);
+  width: 100%;
+  justify-content: center;
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.btn-primary {
+  background: var(--accent-gradient);
+  color: var(--bg-primary);
+  margin-top: 8px;
+
+  &:not(:disabled):hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px rgba(240, 192, 64, 0.25);
+  }
+}
+
+.btn-danger {
+  background: transparent;
+  color: #f87171;
+  border: 1px solid rgba(248, 113, 113, 0.3);
+
+  &:hover {
+    background: rgba(248, 113, 113, 0.08);
+    border-color: #f87171;
+  }
+}
+
+// ── Responsive ─────────────────────────────────────────────────
+@media (max-width: 720px) {
+  .cards-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-page {
+    padding: 40px 16px 60px;
+  }
+}

--- a/src/app/pages/profile/profile.component.ts
+++ b/src/app/pages/profile/profile.component.ts
@@ -1,0 +1,94 @@
+import { Component, OnInit } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { FormsModule } from '@angular/forms'
+import { Router } from '@angular/router'
+import { MatIconModule } from '@angular/material/icon'
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
+import { MatSnackBar } from '@angular/material/snack-bar'
+import { finalize } from 'rxjs/operators'
+import { UserService, UserProfile, ChangePasswordRequest } from '../../services/user.service'
+import { AuthService } from '../auth/auth.service'
+
+@Component({
+  selector: 'app-profile',
+  standalone: true,
+  imports: [CommonModule, FormsModule, MatIconModule, MatProgressSpinnerModule],
+  templateUrl: './profile.component.html',
+  styleUrl: './profile.component.scss',
+})
+export class ProfileComponent implements OnInit {
+  profile: UserProfile | null = null
+  loadingProfile = true
+
+  passwordForm: ChangePasswordRequest = {
+    currentPassword: '',
+    newPassword: '',
+    confirmationPassword: '',
+  }
+  changingPassword = false
+  showCurrentPassword = false
+  showNewPassword = false
+  showConfirmPassword = false
+
+  constructor(
+    private userService: UserService,
+    private authService: AuthService,
+    private snackBar: MatSnackBar,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.userService
+      .getProfile()
+      .pipe(finalize(() => (this.loadingProfile = false)))
+      .subscribe({
+        next: (profile) => (this.profile = profile),
+        error: () => {
+          // Token invalid or expired — clear session and send to login
+          this.authService.logout().subscribe({ complete: () => this.router.navigate(['/login']) })
+        },
+      })
+  }
+
+  get initials(): string {
+    if (!this.profile) return '?'
+    return `${this.profile.firstname[0]}${this.profile.lastname[0]}`.toUpperCase()
+  }
+
+  get fullName(): string {
+    if (!this.profile) return ''
+    return `${this.profile.firstname} ${this.profile.lastname}`
+  }
+
+  onChangePassword(): void {
+    if (this.passwordForm.newPassword !== this.passwordForm.confirmationPassword) {
+      this.snackBar.open('New passwords do not match.', 'Close', { duration: 4000 })
+      return
+    }
+    if (this.passwordForm.newPassword.length < 8) {
+      this.snackBar.open('Password must be at least 8 characters.', 'Close', { duration: 4000 })
+      return
+    }
+
+    this.changingPassword = true
+    this.userService
+      .changePassword(this.passwordForm)
+      .pipe(finalize(() => (this.changingPassword = false)))
+      .subscribe({
+        next: () => {
+          this.snackBar.open('Password updated successfully!', 'Close', { duration: 4000 })
+          this.passwordForm = { currentPassword: '', newPassword: '', confirmationPassword: '' }
+        },
+        error: (err) => {
+          const msg = err?.error?.message ?? 'Failed to update password.'
+          this.snackBar.open(msg, 'Close', { duration: 5000 })
+        },
+      })
+  }
+
+  onLogout(): void {
+    this.authService.logout().subscribe({
+      complete: () => this.router.navigate(['/login']),
+    })
+  }
+}

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@angular/core'
+import { HttpClient } from '@angular/common/http'
+import { Observable } from 'rxjs'
+import { environment } from '../../environments/environment'
+
+/**
+ * Returned by GET /api/v1/user.
+ * The server derives the identity from the Bearer token — callers cannot
+ * request another user's profile. Only these fields are exposed; the
+ * password hash is never included.
+ */
+export interface UserProfile {
+  id: number
+  firstname: string
+  lastname: string
+  email: string
+  username: string
+  role: string
+}
+
+export interface ChangePasswordRequest {
+  currentPassword: string
+  newPassword: string
+  confirmationPassword: string
+}
+
+@Injectable({ providedIn: 'root' })
+export class UserService {
+  private readonly apiUrl = `${environment.apiBaseUrl}/user`
+
+  constructor(private http: HttpClient) {}
+
+  /** Returns only the authenticated user's own profile. */
+  getProfile(): Observable<UserProfile> {
+    return this.http.get<UserProfile>(this.apiUrl)
+  }
+
+  /** Changes the authenticated user's own password. Requires the current password. */
+  changePassword(request: ChangePasswordRequest): Observable<void> {
+    return this.http.patch<void>(this.apiUrl, request)
+  }
+}


### PR DESCRIPTION
## Summary
- **ProfileComponent** at `/profile` — shows account details (read-only) and a change-password form
- **UserService** — typed wrappers for `GET /api/v1/user` (own data only) and `PATCH /api/v1/user`
- **authGuard** — `CanActivateFn` that blocks unauthenticated navigation to `/profile` and redirects to `/login`
- On 401 from the API (expired token), component forces logout + redirects to `/login`

## Security model
The server enforces principle of least privilege — `GET /user` derives identity from the Bearer token via Spring Security `Principal`, so users can only ever read their own data. No `userId` parameter exists. The UI guard is a convenience layer only.

## Test plan
- [ ] Navigate to `/profile` while logged out → redirected to `/login`
- [ ] Log in → navigate to `/profile` → account details loaded
- [ ] Change password form validates inputs (match, min 8 chars)
- [ ] Successful password change shows snackbar and clears form
- [ ] Wrong current password shows server error in snackbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)