### PR TITLE
fix: hero section clips scroll indicator

### DIFF
--- a/src/app/pages/dashboard/dashboard.component.scss
+++ b/src/app/pages/dashboard/dashboard.component.scss
@@ -1,7 +1,12 @@
 // ===== Hero Section =====
+// Toolbar is position:fixed at 64px; page-content scroll container is
+// calc(100vh - 64px) tall, so hero must match to avoid clipping the
+// scroll indicator at the bottom.
+$toolbar-height: 64px;
+
 .hero-section {
   position: relative;
-  min-height: 100vh;
+  min-height: calc(100vh - #{$toolbar-height});
   display: flex;
   align-items: center;
   justify-content: center;
@@ -467,7 +472,9 @@
 // ===== Responsive =====
 @media (max-width: 768px) {
   .hero-section {
-    min-height: 90vh;
+    // Mobile browsers have smaller chrome — use dvh so the scroll indicator
+    // isn't clipped by browser UI (address bar, bottom bar).
+    min-height: calc(100dvh - #{$toolbar-height});
   }
 
   .hero-subtitle {


### PR DESCRIPTION
## Summary
- Hero section `min-height` was `100vh` but the scroll container is `calc(100vh - 64px)` (navbar is `position:fixed; height:64px`)
- The overflow caused the scroll indicator to sit just below the visible area
- Fix: `min-height: calc(100vh - 64px)` on desktop, `calc(100dvh - 64px)` on mobile (dvh accounts for browser chrome like address/bottom bars)

## Test plan
- [ ] Home page loads — "Scroll to explore" indicator fully visible at bottom without scrolling
- [ ] Mobile: indicator still visible with address bar present

🤖 Generated with [Claude Code](https://claude.com/claude-code)