### PR TITLE
fix: double scrollbar, footer gap and off-center scroll indicator

### DIFF
--- a/src/app/pages/dashboard/dashboard.component.scss
+++ b/src/app/pages/dashboard/dashboard.component.scss
@@ -216,8 +216,8 @@ $toolbar-height: 64px;
 .scroll-indicator {
   position: absolute;
   bottom: 32px;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 0;
+  right: 0;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/app/shared/navbar/navbar.component.scss
+++ b/src/app/shared/navbar/navbar.component.scss
@@ -121,6 +121,7 @@ $toolbar-height: 64px;
 // and the orphaned gap below the footer.
 .page-content-with-sidebar {
   margin-top: $toolbar-height;
+  min-height: calc(100vh - #{$toolbar-height});
   width: 100%;
 }
 

--- a/src/app/shared/navbar/navbar.component.scss
+++ b/src/app/shared/navbar/navbar.component.scss
@@ -115,21 +115,21 @@ $toolbar-height: 64px;
 }
 
 // ===== Page Layout =====
+// No fixed height — the window is the single scroll container.
+// mat-drawer-content also has overflow:auto by default; removing the
+// inner overflow-y:auto from .page-content eliminates the double scrollbar
+// and the orphaned gap below the footer.
 .page-content-with-sidebar {
-  height: calc(100vh - #{$toolbar-height});
   margin-top: $toolbar-height;
   width: 100%;
 }
 
 .nav-bar-container {
   width: 100%;
-  height: 100%;
 }
 
 .page-content {
-  height: 100%;
   width: 100%;
-  overflow-y: auto;
 }
 
 // ===== Sidenav =====

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -105,6 +105,18 @@ a:hover {
   background: var(--text-muted);
 }
 
+/* ===== Angular Material Layout Overrides ===== */
+/* mat-drawer-content has built-in height:100% + overflow:auto which creates
+   a second scroll container alongside the window scrollbar. Force it to flow
+   naturally so the browser window is the single scroll container. */
+.mat-drawer-container {
+  height: auto !important;
+}
+.mat-drawer-content {
+  height: auto !important;
+  overflow-y: visible !important;
+}
+
 /* ===== Utility Classes ===== */
 .glass {
   background: var(--bg-glass);


### PR DESCRIPTION
## Summary
- **Double scrollbar**: removed the fixed-height inner scroll container (`.page-content { height:100%; overflow-y:auto }` inside `mat-drawer-container`). Angular Material's `mat-drawer-content` already scrolls by default — having a second `overflow-y:auto` produced two scrollbars simultaneously.
- **Gap after footer**: same root cause. The `mat-drawer-content` was extending below the footer content because it had a fixed height with no content to fill it. Natural page flow eliminates the orphaned space.
- **Scroll indicator off-center**: replaced `left:50%; transform:translateX(-50%)` with `left:0; right:0` so the element stretches to the container's full width and its children are centred by existing flexbox — avoids any offset side-effects from `mat-drawer-content`'s internal transforms.

## Test plan
- [ ] Home page: single scrollbar, scroll indicator centred, footer flush at bottom
- [ ] Projects / About / Profile pages: single scrollbar, footer flush
- [ ] Mobile: no double scrollbar, scroll indicator hidden (already `display:none` below 768px)
- [ ] Sidenav toggle still opens/closes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)