### PR TITLE
fix: remove redundant nullish coalescing in stats-explorer template

### DIFF
--- a/src/app/shared/stats-explorer/stats-explorer.component.html
+++ b/src/app/shared/stats-explorer/stats-explorer.component.html
@@ -22,8 +22,7 @@
         @for (param of config.params; track param.key) {
           <div class="param-row">
             <span class="param-label"
-              >{{ param.label }}:
-              <strong>{{ paramValues[param.key] ?? param.default }}</strong></span
+              >{{ param.label }}: <strong>{{ paramValues[param.key] }}</strong></span
             >
             <mat-slider
               [min]="param.min"


### PR DESCRIPTION
## Summary
- Removes `?? param.default` from the `paramValues[param.key]` binding in `stats-explorer.component.html`
- `paramValues` is typed as `Record<string, number>` and all keys are initialised before the template renders, so the fallback was unreachable
- Clears the `NG8102` Angular build warning

## Test plan
- [ ] Build produces zero warnings
- [ ] Stats explorer on the home page still renders parameter values correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)