### PR TITLE
feat: add ShowUpMD to portfolio

### DIFF
--- a/src/app/pages/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/dashboard.component.html
@@ -75,7 +75,15 @@
         [routerLink]="['/project']"
         [style.animation-delay]="i * 0.1 + 's'"
       >
-        <div class="project-icon">{{ project.icon }}</div>
+        <div class="project-icon">
+          <img
+            *ngIf="project.logo"
+            [src]="project.logo"
+            [alt]="project.title + ' logo'"
+            class="project-logo"
+          />
+          <ng-container *ngIf="!project.logo">{{ project.icon }}</ng-container>
+        </div>
         <h3 class="project-title">{{ project.title }}</h3>
         <p class="project-desc">{{ project.description }}</p>
         <div class="project-tags">

--- a/src/app/pages/dashboard/dashboard.component.scss
+++ b/src/app/pages/dashboard/dashboard.component.scss
@@ -347,6 +347,15 @@ $toolbar-height: 64px;
 .project-icon {
   font-size: 2.5rem;
   margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+}
+
+.project-logo {
+  width: 48px;
+  height: 48px;
+  border-radius: 10px;
+  object-fit: contain;
 }
 
 .project-title {

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -58,6 +58,13 @@ export class DashboardComponent {
 
   featuredProjects: FeaturedProject[] = [
     {
+      title: 'ShowUpMD — Maryland Civic Engagement App',
+      description:
+        'Full-stack civic app for Maryland voters — district lookup, candidate browser, legislation tracker, and an AI chat assistant powered by a RAG pipeline over real government data.',
+      tags: ['Next.js', 'FastAPI', 'PostgreSQL', 'pgvector', 'AI/RAG'],
+      icon: '🗳️',
+    },
+    {
       title: 'Research Portfolio Platform',
       description:
         'Architected a full-stack platform to showcase data analysis and research, featuring an Angular frontend, Spring Boot authentication, and FastAPI resource server.',

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -15,6 +15,7 @@ interface FeaturedProject {
   description: string
   tags: string[]
   icon: string
+  logo?: string
 }
 
 @Component({
@@ -63,6 +64,7 @@ export class DashboardComponent {
         'Full-stack civic app for Maryland voters — district lookup, candidate browser, legislation tracker, and an AI chat assistant powered by a RAG pipeline over real government data.',
       tags: ['Next.js', 'FastAPI', 'PostgreSQL', 'pgvector', 'AI/RAG'],
       icon: '🗳️',
+      logo: 'assets/showupmd-logo.svg',
     },
     {
       title: 'Research Portfolio Platform',

--- a/src/app/pages/project/project.component.html
+++ b/src/app/pages/project/project.component.html
@@ -28,7 +28,15 @@
         [style.animation-delay]="i * 0.1 + 's'"
       >
         <div class="card-header">
-          <span class="card-icon">{{ project.icon }}</span>
+          <span class="card-icon">
+            <img
+              *ngIf="project.logo"
+              [src]="project.logo"
+              [alt]="project.title + ' logo'"
+              class="card-logo"
+            />
+            <ng-container *ngIf="!project.logo">{{ project.icon }}</ng-container>
+          </span>
           <span class="card-category">{{ project.category }}</span>
         </div>
         <h3 class="card-title">{{ project.title }}</h3>

--- a/src/app/pages/project/project.component.scss
+++ b/src/app/pages/project/project.component.scss
@@ -96,6 +96,15 @@
 
 .card-icon {
   font-size: 2.5rem;
+  display: flex;
+  align-items: center;
+}
+
+.card-logo {
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  object-fit: contain;
 }
 
 .card-category {

--- a/src/app/pages/project/project.component.ts
+++ b/src/app/pages/project/project.component.ts
@@ -26,6 +26,15 @@ export class ProjectComponent {
 
   projects: Project[] = [
     {
+      title: 'ShowUpMD — Maryland Civic Engagement App',
+      description:
+        'Full-stack civic web app that helps Maryland residents prepare for the 2026 primary election. Enter your address to instantly see your congressional and state legislative districts, current representatives, every candidate on your ballot, and relevant legislation — all in one place. Features "Civvy", an AI chat assistant powered by a RAG pipeline (BGE-M3 embeddings + pgvector) that answers plain-English questions about Maryland bills. Data is ingested from 5+ government sources including the Maryland General Assembly API, OpenStates, Census Geocoder, and the MD State Board of Elections.',
+      tags: ['Next.js', 'FastAPI', 'PostgreSQL', 'pgvector', 'AI/RAG', 'Cloudflare'],
+      category: 'Full Stack',
+      icon: '🗳️',
+      demo: 'https://showupmd.org',
+    },
+    {
       title: 'Research Portfolio Platform',
       description:
         'Architected a full-stack portfolio platform to showcase exploratory data analysis and machine learning research. Designed an Angular frontend integrated with a secure Java Spring Boot authentication API and a Python FastAPI resource server for hosting machine learning models and utilities.',

--- a/src/app/pages/project/project.component.ts
+++ b/src/app/pages/project/project.component.ts
@@ -8,6 +8,7 @@ interface Project {
   tags: string[]
   category: string
   icon: string
+  logo?: string
   github?: string
   demo?: string
 }
@@ -32,6 +33,7 @@ export class ProjectComponent {
       tags: ['Next.js', 'FastAPI', 'PostgreSQL', 'pgvector', 'AI/RAG', 'Cloudflare'],
       category: 'Full Stack',
       icon: '🗳️',
+      logo: 'assets/showupmd-logo.svg',
       demo: 'https://showupmd.org',
     },
     {

--- a/src/assets/showupmd-logo.svg
+++ b/src/assets/showupmd-logo.svg
@@ -1,0 +1,15 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <clipPath id="logo-clip">
+      <circle cx="50" cy="50" r="50" />
+    </clipPath>
+  </defs>
+  <!-- Gold left half -->
+  <circle cx="50" cy="50" r="50" fill="#F2C84B" />
+  <!-- Red right half -->
+  <rect x="50" y="0" width="50" height="100" fill="#D63B2F" clip-path="url(#logo-clip)" />
+  <!-- White arrow: vertical line -->
+  <path d="M50 82 L50 28" stroke="#fff" stroke-width="13" stroke-linecap="round" />
+  <!-- White arrow: chevron head -->
+  <path d="M24 52 L50 22 L76 52" stroke="#fff" stroke-width="13" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+</svg>


### PR DESCRIPTION
## Summary
- Adds **ShowUpMD** as the first featured project on the home page and the first card on the Projects page
- Live demo link: https://showupmd.org
- Full description covering district lookup, candidate browser, legislation tracker, and the Civvy AI chat assistant (RAG / pgvector)
- Tags: Next.js · FastAPI · PostgreSQL · pgvector · AI/RAG · Cloudflare
- GitHub link omitted (private repo)

## Test plan
- [ ] Home page: ShowUpMD appears as the first featured project card
- [ ] Projects page: ShowUpMD appears first with a working "Demo" button linking to showupmd.org
- [ ] "Full Stack" filter on Projects page includes ShowUpMD
- [ ] No new build warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)