### PR TITLE
feat: attach X-API-Key to all backend requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ResearchPortfolio-UI
 
-Angular 17 frontend for my personal research portfolio — Angular Material, JWT auth, Cloudflare Pages hosting.
+Angular 17 frontend for my personal research portfolio — Angular Material, dark theme, Cloudflare Pages hosting.
 
 ## Stack
 
 - Angular 17 (standalone components) + Angular Material
-- RxJS + HTTP interceptor for JWT auth
+- RxJS + HTTP interceptor for JWT auth and API key headers
 - Cloudflare Pages (auto-deploys on merge to `main`)
 
 ## Companion services
@@ -25,16 +25,27 @@ Dev values are hardcoded in `src/environments/environment.ts`. Production values
 
 ## Cloudflare Pages build settings
 
-| Setting          | Value                                                                                                                                                                                                                                                              |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Build command    | `sed -i "s\|%%API_URL%%\|$API_URL\|g" src/environments/environment.prod.ts && sed -i "s\|%%MODEL_API_URL%%\|$MODEL_API_URL\|g" src/environments/environment.prod.ts && sed -i "s\|%%APP_URL%%\|$APP_URL\|g" src/environments/environment.prod.ts && npm run build` |
-| Output directory | `dist/research-portfolio-ui/browser`                                                                                                                                                                                                                               |
+| Setting          | Value                                |
+| ---------------- | ------------------------------------ |
+| Build command    | see below                            |
+| Output directory | `dist/research-portfolio-ui/browser` |
 
-**Environment variables (set in CF Pages dashboard):**
+**Build command** (substitutes `%%PLACEHOLDER%%` tokens in `environment.prod.ts`):
 
-| Variable        | Purpose                                               |
-| --------------- | ----------------------------------------------------- |
-| `API_URL`       | Auth API base URL (e.g. `https://<auth-host>/api/v1`) |
-| `MODEL_API_URL` | FastAPI model server base URL                         |
-| `APP_URL`       | Public URL of this app                                |
-| `NODE_VERSION`  | `22`                                                  |
+```bash
+sed -i "s|%%API_URL%%|$API_URL|g" src/environments/environment.prod.ts \
+  && sed -i "s|%%MODEL_API_URL%%|$MODEL_API_URL|g" src/environments/environment.prod.ts \
+  && sed -i "s|%%APP_URL%%|$APP_URL|g" src/environments/environment.prod.ts \
+  && sed -i "s|%%FASTAPI_API_KEY%%|$FASTAPI_API_KEY|g" src/environments/environment.prod.ts \
+  && npm run build
+```
+
+**Environment variables (set in Cloudflare Pages dashboard):**
+
+| Variable          | Purpose                                                                    |
+| ----------------- | -------------------------------------------------------------------------- |
+| `API_URL`         | Auth API base URL                                                          |
+| `MODEL_API_URL`   | FastAPI model server base URL                                              |
+| `APP_URL`         | Public URL of this app                                                     |
+| `FASTAPI_API_KEY` | Backend API key — copy from server `.env` after running `bootstrap_env.sh` |
+| `NODE_VERSION`    | `22`                                                                       |

--- a/src/app/auth.interceptor.ts
+++ b/src/app/auth.interceptor.ts
@@ -1,17 +1,32 @@
 import { HttpInterceptorFn } from '@angular/common/http'
 import { inject } from '@angular/core'
 import { AuthService } from './pages/auth/auth.service'
+import { environment } from '../environments/environment'
 
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const authService = inject(AuthService)
-  const token = authService.getAuthTokenValue()
+  let headers = req.headers
 
+  // ── JWT Bearer — attached for authenticated user requests (AuthAPI routes) ──
+  const token = authService.getAuthTokenValue()
   if (token) {
-    const cloned = req.clone({
-      headers: req.headers.set('Authorization', 'Bearer ' + token),
-    })
-    return next(cloned)
+    headers = headers.set('Authorization', 'Bearer ' + token)
   }
 
-  return next(req)
+  // ── API key — attached to every request going to either backend service ──
+  // Sent to both the AuthAPI (Spring Boot) and the FastAPI model server.
+  // The key is embedded in the Angular build at Cloudflare Pages build time;
+  // it is not user-specific and not truly secret — it acts as a lightweight
+  // gate against anonymous bot abuse. Real protection is CORS + CF rate limiting.
+  const isBackendRequest =
+    req.url.startsWith(environment.apiBaseUrl) || req.url.startsWith(environment.modelApiUrl)
+  if (isBackendRequest && environment.apiKey) {
+    headers = headers.set('X-API-Key', environment.apiKey)
+  }
+
+  // Only clone the request if we actually modified headers
+  if (headers === req.headers) {
+    return next(req)
+  }
+  return next(req.clone({ headers }))
 }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -3,4 +3,9 @@ export const environment = {
   apiBaseUrl: '%%API_URL%%',
   modelApiUrl: '%%MODEL_API_URL%%',
   appUrl: '%%APP_URL%%',
+  // Replaced at Cloudflare Pages build time via the FASTAPI_API_KEY env var.
+  // Sent as X-API-Key to both the AuthAPI and the FastAPI model server.
+  // Set under: Pages → researchportfolio-ui → Settings → Environment Variables
+  //   FASTAPI_API_KEY = <value of RP_FASTAPI_API_KEY from .env>
+  apiKey: '%%FASTAPI_API_KEY%%',
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,4 +3,7 @@ export const environment = {
   apiBaseUrl: 'http://localhost:8080/api/v1',
   modelApiUrl: 'http://localhost:8000',
   appUrl: 'http://localhost:4200',
+  // Sent as X-API-Key to both the AuthAPI and the FastAPI model server.
+  // Must match RP_FASTAPI_API_KEY in your local .env (both services share the same key).
+  apiKey: 'dev-api-key',
 }


### PR DESCRIPTION
## Summary
- Adds `apiKey` field to `environment.ts` (dev: `'dev-api-key'`) and `environment.prod.ts` (prod: `%%FASTAPI_API_KEY%%` replaced at Cloudflare Pages build time)
- `authInterceptor` now attaches `X-API-Key` header to every request going to `apiBaseUrl` (AuthAPI) or `modelApiUrl` (FastAPI model server)
- Both backends share the same key — only one Cloudflare Pages env var needed

## Cloudflare Pages setup (one-time)
Add under: Pages → researchportfolio-ui → Settings → Environment Variables
```
FASTAPI_API_KEY = <value of RP_FASTAPI_API_KEY from .env>
```

## Test plan
- [ ] Dev: stats explorer calls succeed with `dev-api-key` matching the local server env
- [ ] Prod build: `environment.prod.ts` has `%%FASTAPI_API_KEY%%` replaced correctly
- [ ] Network tab: outbound requests to `/api/v1/...` and `:8000/...` carry `X-API-Key` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)