### PR TITLE
feat: add live World Cup 2026 prediction page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { AuthComponent } from './pages/auth/auth.component'
 import { ProjectComponent } from './pages/project/project.component'
 import { ProjectDetailComponent } from './pages/project-detail/project-detail.component'
 import { ProfileComponent } from './pages/profile/profile.component'
+import { WorldCupComponent } from './pages/world-cup/world-cup.component'
 import { PageNotFoundComponent } from './pages/page-not-found/page-not-found.component'
 import { authGuard } from './guards/auth.guard'
 
@@ -16,6 +17,7 @@ export const routes: Routes = [
   { path: 'register', component: AuthComponent },
   { path: 'project', component: ProjectComponent },
   { path: 'project/:id', component: ProjectDetailComponent },
+  { path: 'world-cup', component: WorldCupComponent },
   { path: 'profile', component: ProfileComponent, canActivate: [authGuard] },
   { path: '**', component: PageNotFoundComponent },
 ]

--- a/src/app/data/projects.ts
+++ b/src/app/data/projects.ts
@@ -29,9 +29,41 @@ export interface Project {
   /** Bullet-point highlights shown on the detail page */
   highlights?: string[]
   status?: 'live' | 'in-progress' | 'research'
+  /**
+   * Opt-in identifier for a live-data widget rendered above the About
+   * section on the detail page. The detail-page component switches on
+   * this value to render the matching embed component.
+   */
+  liveEmbed?: 'world-cup-summary'
 }
 
 export const PROJECTS: Project[] = [
+  {
+    id: 'world-cup-prediction',
+    title: 'World Cup 2026 Live Prediction Engine',
+    shortDescription:
+      'Calibrated XGBoost + 2M-simulation Monte Carlo pipeline that predicts the 2026 FIFA World Cup. Auto-refreshes daily; played group-stage matches are locked into every simulation.',
+    description:
+      'End-to-end machine-learning system that forecasts the 2026 FIFA World Cup. Trained a calibrated XGBoost classifier on ~12,000 international matches since 2014 with positional FIFA-rating features, Elo ratings dating back to 1872, rolling form, and tournament-weighted sample weights. Probabilities are isotonically calibrated and fed into a Monte Carlo simulator that runs 2 million tournaments, bridging classification probabilities to score distributions via a Poisson xG solver. The pipeline updates daily during the tournament: every completed group-stage match is locked into every subsequent simulation, sharpening predictions as the bracket unfolds. Each daily snapshot is versioned in Postgres so the UI can show how predictions evolve over time.',
+    tags: ['Python', 'XGBoost', 'FastAPI', 'PostgreSQL', 'Angular', 'Chart.js'],
+    category: 'Machine Learning',
+    icon: '⚽',
+    repoLinks: [
+      { label: 'FastAPI Server', url: 'https://github.com/regmibishal1/ResearchPortfolio-FastAPI' },
+      { label: 'Angular UI', url: 'https://github.com/regmibishal1/ResearchPortfolio-UI' },
+    ],
+    demo: '/world-cup',
+    liveEmbed: 'world-cup-summary',
+    status: 'live',
+    highlights: [
+      'Calibrated XGBoost multi-class model on win/draw/loss with isotonic probability calibration',
+      'Nine orthogonal features: Elo difference, positional squad strength (GK/DEF/MID/ATT), rolling form, neutral-venue flag',
+      '2M Monte Carlo simulations per snapshot, parallelised across CPU cores with optional CuPy GPU acceleration',
+      'Poisson xG solver maps 3-class probabilities to realistic scorelines for FIFA group-stage tiebreakers',
+      'Daily auto-refresh: completed matches override Poisson sampling so predictions sharpen as the tournament unfolds',
+      'Per-snapshot versioning in Postgres with isolated read-only schema role for the public read endpoints',
+    ],
+  },
   {
     id: 'showupmd',
     title: 'ShowUpMD — Maryland Civic Engagement App',

--- a/src/app/pages/project-detail/project-detail.component.html
+++ b/src/app/pages/project-detail/project-detail.component.html
@@ -75,6 +75,18 @@
 
   <!-- ===== Body ===== -->
   <div class="detail-body">
+    <!-- Live embed (opt-in per project via project.liveEmbed) -->
+    <section
+      class="detail-section animate-in animate-in-delay-2"
+      *ngIf="project.liveEmbed === 'world-cup-summary'"
+    >
+      <h2 class="section-heading">
+        <mat-icon>insights</mat-icon>
+        Live Snapshot
+      </h2>
+      <app-world-cup-summary></app-world-cup-summary>
+    </section>
+
     <!-- About -->
     <section class="detail-section animate-in animate-in-delay-2">
       <h2 class="section-heading">

--- a/src/app/pages/project-detail/project-detail.component.ts
+++ b/src/app/pages/project-detail/project-detail.component.ts
@@ -4,11 +4,12 @@ import { ActivatedRoute, Router, RouterModule } from '@angular/router'
 import { MatIconModule } from '@angular/material/icon'
 import { Title, Meta } from '@angular/platform-browser'
 import { PROJECTS, Project } from '../../data/projects'
+import { WorldCupSummaryComponent } from '../../shared/world-cup-summary/world-cup-summary.component'
 
 @Component({
   selector: 'app-project-detail',
   standalone: true,
-  imports: [CommonModule, RouterModule, MatIconModule],
+  imports: [CommonModule, RouterModule, MatIconModule, WorldCupSummaryComponent],
   templateUrl: './project-detail.component.html',
   styleUrl: './project-detail.component.scss',
 })

--- a/src/app/pages/world-cup/world-cup.component.html
+++ b/src/app/pages/world-cup/world-cup.component.html
@@ -1,0 +1,286 @@
+<div class="wc-page">
+  <!-- ===== Back link ===== -->
+  <nav class="breadcrumb">
+    <a [routerLink]="['/project', 'world-cup-prediction']" class="back-link">
+      <mat-icon>arrow_back</mat-icon>
+      <span>Project overview</span>
+    </a>
+  </nav>
+
+  <!-- ===== Hero ===== -->
+  <header class="wc-hero">
+    <div class="hero-text">
+      <span class="hero-eyebrow">Live Predictions</span>
+      <h1>FIFA World Cup 2026</h1>
+      <p class="hero-sub">
+        Calibrated XGBoost + 2M-simulation Monte Carlo, refreshed daily. Played group-stage matches
+        are locked into every simulation.
+      </p>
+    </div>
+
+    <div class="hero-meta" *ngIf="latest as l">
+      <div class="meta-pill">
+        <span class="meta-label">As of</span>
+        <span class="meta-value">{{ l.run.as_of_date | date: 'longDate' }}</span>
+      </div>
+      <div class="meta-pill">
+        <span class="meta-label">Simulations</span>
+        <span class="meta-value">{{ l.run.n_simulations | number }}</span>
+      </div>
+      <div class="meta-pill">
+        <span class="meta-label">Matches locked</span>
+        <span class="meta-value">{{ l.run.n_played_matches_locked }}</span>
+      </div>
+    </div>
+  </header>
+
+  <!-- ===== Loading ===== -->
+  <div class="state-block" *ngIf="loading">
+    <mat-spinner diameter="36"></mat-spinner>
+    <span>Loading predictions...</span>
+  </div>
+
+  <!-- ===== Error ===== -->
+  <div class="state-block state-error" *ngIf="error && !loading">
+    <mat-icon>error_outline</mat-icon>
+    <span>{{ error }}</span>
+  </div>
+
+  <!-- ===== Content ===== -->
+  <ng-container *ngIf="!loading && !error">
+    <mat-tab-group class="wc-tabs" animationDuration="200ms" mat-stretch-tabs="false">
+      <!-- ─── Leaderboard ─── -->
+      <mat-tab label="Leaderboard">
+        <section class="panel">
+          <p class="panel-sub">
+            Probability of reaching each tournament stage. Sorted by championship odds.
+          </p>
+          <div class="leaderboard-wrap">
+            <table class="leaderboard">
+              <thead>
+                <tr>
+                  <th class="rank-col">#</th>
+                  <th class="team-col">Team</th>
+                  <th>Winner</th>
+                  <th>Final</th>
+                  <th>Semi</th>
+                  <th>QF</th>
+                  <th>R16</th>
+                  <th>R32</th>
+                  <th class="elo-col">Elo</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr *ngFor="let row of latest?.leaderboard; let i = index; trackBy: trackByTeam">
+                  <td class="rank-col">{{ i + 1 }}</td>
+                  <td class="team-col">{{ row.team }}</td>
+                  <td class="pct-cell pct-winner">
+                    <span class="bar" [style.width.%]="row.winner_pct * 5"></span>
+                    <span class="pct-text">{{ row.winner_pct | number: '1.2-2' }}%</span>
+                  </td>
+                  <td>{{ row.final_pct | number: '1.1-1' }}%</td>
+                  <td>{{ row.sf_pct | number: '1.1-1' }}%</td>
+                  <td>{{ row.qf_pct | number: '1.1-1' }}%</td>
+                  <td>{{ row.r16_pct | number: '1.1-1' }}%</td>
+                  <td>{{ row.r32_pct | number: '1.1-1' }}%</td>
+                  <td class="elo-col">{{ row.elo | number: '1.0-0' }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </mat-tab>
+
+      <!-- ─── Bracket ─── -->
+      <mat-tab label="Bracket">
+        <section class="panel">
+          <p class="panel-sub">
+            Most-probable path through the tournament. Lock-ins from played matches feed into each
+            downstream prediction.
+          </p>
+
+          <h3 class="bracket-section-title">Knockout bracket</h3>
+          <div class="bracket-scroll">
+            <div class="bracket" *ngIf="bracketHalves && bracket">
+              <!-- ── LEFT HALF ── -->
+              <div class="round round-r32">
+                <div class="round-label">Round of 32</div>
+                <div class="match" *ngFor="let m of bracketHalves.left.r32; trackBy: trackByPair">
+                  <div class="team" [class.team-winner]="advancers.r32.has(m[0])">
+                    <span class="team-name">{{ m[0] }}</span>
+                  </div>
+                  <div class="team" [class.team-winner]="advancers.r32.has(m[1])">
+                    <span class="team-name">{{ m[1] }}</span>
+                  </div>
+                </div>
+              </div>
+
+              <div class="round round-r16">
+                <div class="round-label">Round of 16</div>
+                <div class="match" *ngFor="let m of bracketHalves.left.r16; trackBy: trackByPair">
+                  <div class="team" [class.team-winner]="advancers.r16.has(m[0])">
+                    <span class="team-name">{{ m[0] }}</span>
+                  </div>
+                  <div class="team" [class.team-winner]="advancers.r16.has(m[1])">
+                    <span class="team-name">{{ m[1] }}</span>
+                  </div>
+                </div>
+              </div>
+
+              <div class="round round-qf">
+                <div class="round-label">Quarter-final</div>
+                <div class="match" *ngFor="let m of bracketHalves.left.qf; trackBy: trackByPair">
+                  <div class="team" [class.team-winner]="advancers.qf.has(m[0])">
+                    <span class="team-name">{{ m[0] }}</span>
+                  </div>
+                  <div class="team" [class.team-winner]="advancers.qf.has(m[1])">
+                    <span class="team-name">{{ m[1] }}</span>
+                  </div>
+                </div>
+              </div>
+
+              <div class="round round-sf">
+                <div class="round-label">Semi-final</div>
+                <div class="match" *ngFor="let m of bracketHalves.left.sf; trackBy: trackByPair">
+                  <div class="team" [class.team-winner]="advancers.sf.has(m[0])">
+                    <span class="team-name">{{ m[0] }}</span>
+                  </div>
+                  <div class="team" [class.team-winner]="advancers.sf.has(m[1])">
+                    <span class="team-name">{{ m[1] }}</span>
+                  </div>
+                </div>
+              </div>
+
+              <!-- ── CENTER: FINAL + CHAMPION ── -->
+              <div class="round round-final">
+                <div class="round-label">Final</div>
+                <div class="match match-final">
+                  <div
+                    class="team"
+                    [class.team-winner]="bracket.final_pair[0] === bracket.champion"
+                  >
+                    <span class="team-name">{{ bracket.final_pair[0] }}</span>
+                  </div>
+                  <div
+                    class="team"
+                    [class.team-winner]="bracket.final_pair[1] === bracket.champion"
+                  >
+                    <span class="team-name">{{ bracket.final_pair[1] }}</span>
+                  </div>
+                </div>
+                <div class="champ-pill">
+                  <mat-icon class="trophy">emoji_events</mat-icon>
+                  <div>
+                    <span class="champ-label">Predicted Champion</span>
+                    <span class="champ-name">{{ bracket.champion }}</span>
+                  </div>
+                </div>
+              </div>
+
+              <!-- ── RIGHT HALF (mirrored) ── -->
+              <div class="round round-sf">
+                <div class="round-label">Semi-final</div>
+                <div class="match" *ngFor="let m of bracketHalves.right.sf; trackBy: trackByPair">
+                  <div class="team" [class.team-winner]="advancers.sf.has(m[0])">
+                    <span class="team-name">{{ m[0] }}</span>
+                  </div>
+                  <div class="team" [class.team-winner]="advancers.sf.has(m[1])">
+                    <span class="team-name">{{ m[1] }}</span>
+                  </div>
+                </div>
+              </div>
+
+              <div class="round round-qf">
+                <div class="round-label">Quarter-final</div>
+                <div class="match" *ngFor="let m of bracketHalves.right.qf; trackBy: trackByPair">
+                  <div class="team" [class.team-winner]="advancers.qf.has(m[0])">
+                    <span class="team-name">{{ m[0] }}</span>
+                  </div>
+                  <div class="team" [class.team-winner]="advancers.qf.has(m[1])">
+                    <span class="team-name">{{ m[1] }}</span>
+                  </div>
+                </div>
+              </div>
+
+              <div class="round round-r16">
+                <div class="round-label">Round of 16</div>
+                <div class="match" *ngFor="let m of bracketHalves.right.r16; trackBy: trackByPair">
+                  <div class="team" [class.team-winner]="advancers.r16.has(m[0])">
+                    <span class="team-name">{{ m[0] }}</span>
+                  </div>
+                  <div class="team" [class.team-winner]="advancers.r16.has(m[1])">
+                    <span class="team-name">{{ m[1] }}</span>
+                  </div>
+                </div>
+              </div>
+
+              <div class="round round-r32">
+                <div class="round-label">Round of 32</div>
+                <div class="match" *ngFor="let m of bracketHalves.right.r32; trackBy: trackByPair">
+                  <div class="team" [class.team-winner]="advancers.r32.has(m[0])">
+                    <span class="team-name">{{ m[0] }}</span>
+                  </div>
+                  <div class="team" [class.team-winner]="advancers.r32.has(m[1])">
+                    <span class="team-name">{{ m[1] }}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <h3 class="bracket-section-title">Group winners</h3>
+          <div class="groups-grid" *ngIf="bracket">
+            <div class="group-card" *ngFor="let g of groupKeys; trackBy: trackByGroup">
+              <span class="group-label">Group {{ g }}</span>
+              <ol class="group-list">
+                <li>{{ bracket!.group_winners[g][0] }}</li>
+                <li>{{ bracket!.group_winners[g][1] }}</li>
+              </ol>
+            </div>
+          </div>
+
+          <h3 class="bracket-section-title">Best 8 third-placed teams</h3>
+          <div class="thirds-row" *ngIf="bracket">
+            <span class="third-chip" *ngFor="let t of bracket.best_thirds">{{ t }}</span>
+          </div>
+        </section>
+      </mat-tab>
+
+      <!-- ─── History ─── -->
+      <mat-tab label="History">
+        <section class="panel">
+          <p class="panel-sub">
+            Championship probability over time for the top 10 teams as of the latest snapshot. Each
+            point is one daily prediction run.
+          </p>
+          <div class="chart-wrapper">
+            <canvas #historyCanvas></canvas>
+          </div>
+        </section>
+      </mat-tab>
+
+      <!-- ─── Played matches ─── -->
+      <mat-tab label="Played">
+        <section class="panel">
+          <p class="panel-sub">
+            Group-stage results that have been locked into every simulation in the latest run.
+          </p>
+          <div class="matches-day" *ngFor="let day of matchesByDate; trackBy: trackByDate">
+            <h4 class="day-label">{{ day.date | date: 'mediumDate' }}</h4>
+            <div class="matches-list">
+              <div class="match-card" *ngFor="let m of day.matches; trackBy: trackByMatch">
+                <span class="match-group" *ngIf="m.group_name"> Group {{ m.group_name }} </span>
+                <span class="match-teams">
+                  {{ m.home_team }}
+                  <strong>{{ m.home_score }} - {{ m.away_score }}</strong>
+                  {{ m.away_team }}
+                </span>
+              </div>
+            </div>
+          </div>
+          <p *ngIf="matchesByDate.length === 0" class="empty-msg">No matches locked in yet.</p>
+        </section>
+      </mat-tab>
+    </mat-tab-group>
+  </ng-container>
+</div>

--- a/src/app/pages/world-cup/world-cup.component.scss
+++ b/src/app/pages/world-cup/world-cup.component.scss
@@ -1,0 +1,670 @@
+// Palette matches the existing dark theme (stats-explorer / project-detail).
+$bg-1: #11111b;
+$bg-2: #181825;
+$bg-3: #1e1e2e;
+$bg-4: #313244;
+$text: #cdd6f4;
+$muted: #a6adc8;
+$accent: #89b4fa;
+$accent-2: #a6e3a1;
+$accent-3: #fab387;
+$accent-4: #f38ba8;
+
+.wc-page {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 24px 24px 64px;
+  color: $text;
+}
+
+// ── Back link ────────────────────────────────────────────────────────
+.breadcrumb {
+  margin-bottom: 16px;
+}
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: $muted;
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: color 0.15s ease;
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+  &:hover {
+    color: $accent;
+  }
+}
+
+// ── Hero ─────────────────────────────────────────────────────────────
+.wc-hero {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 28px 32px;
+  background: linear-gradient(135deg, $bg-3 0%, $bg-2 100%);
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  margin-bottom: 24px;
+}
+
+.hero-text {
+  flex: 1;
+  min-width: 260px;
+}
+
+.hero-eyebrow {
+  display: inline-block;
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: $accent;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+h1 {
+  margin: 0 0 8px;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.hero-sub {
+  margin: 0;
+  color: $muted;
+  font-size: 0.95rem;
+  max-width: 60ch;
+  line-height: 1.5;
+}
+
+.hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.meta-pill {
+  background: $bg-2;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 12px;
+  padding: 10px 16px;
+  min-width: 120px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.meta-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: $muted;
+}
+
+.meta-value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: $text;
+}
+
+// ── State blocks ─────────────────────────────────────────────────────
+.state-block {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 40px;
+  justify-content: center;
+  color: $muted;
+}
+
+.state-error {
+  color: $accent-4;
+  mat-icon {
+    color: $accent-4;
+  }
+}
+
+// ── Tab group overrides ──────────────────────────────────────────────
+.wc-tabs {
+  background: $bg-3;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  overflow: hidden;
+
+  ::ng-deep {
+    .mat-mdc-tab-header {
+      background: $bg-2;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+    }
+    .mat-mdc-tab .mdc-tab__text-label {
+      color: $muted;
+      font-weight: 500;
+    }
+    .mat-mdc-tab.mdc-tab--active .mdc-tab__text-label {
+      color: $accent;
+    }
+    .mdc-tab-indicator__content--underline {
+      border-color: $accent !important;
+    }
+  }
+}
+
+.panel {
+  padding: 24px;
+}
+
+.panel-sub {
+  color: $muted;
+  margin: 0 0 20px;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+// ── Leaderboard ──────────────────────────────────────────────────────
+.leaderboard-wrap {
+  overflow-x: auto;
+}
+
+.leaderboard {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+
+  thead th {
+    text-align: left;
+    color: $muted;
+    font-weight: 500;
+    padding: 8px 12px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    font-size: 0.78rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+  tbody td {
+    padding: 10px 12px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+  }
+  tbody tr:hover {
+    background: rgba(137, 180, 250, 0.04);
+  }
+  .rank-col {
+    width: 36px;
+    color: $muted;
+  }
+  .team-col {
+    font-weight: 600;
+    white-space: nowrap;
+  }
+  .elo-col {
+    color: $muted;
+    text-align: right;
+    width: 70px;
+  }
+  .pct-cell {
+    position: relative;
+    min-width: 140px;
+  }
+  .pct-winner {
+    .bar {
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      background: linear-gradient(90deg, rgba(137, 180, 250, 0.22), rgba(137, 180, 250, 0.05));
+      border-radius: 4px;
+      max-width: 100%;
+    }
+    .pct-text {
+      position: relative;
+      font-weight: 600;
+      color: $accent;
+    }
+  }
+}
+
+// ── Bracket ──────────────────────────────────────────────────────────
+.bracket-section-title {
+  margin: 28px 0 12px;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: $muted;
+  font-weight: 600;
+}
+
+.groups-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.group-card {
+  background: $bg-2;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 10px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.group-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: $muted;
+}
+
+.group-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  counter-reset: gp;
+
+  li {
+    counter-increment: gp;
+    font-size: 0.88rem;
+    padding: 2px 0;
+
+    &::before {
+      content: counter(gp) '. ';
+      color: $accent-3;
+      font-weight: 600;
+    }
+  }
+}
+
+.thirds-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.third-chip {
+  background: $bg-2;
+  border: 1px solid rgba(250, 179, 135, 0.25);
+  color: $accent-3;
+  border-radius: 999px;
+  padding: 4px 12px;
+  font-size: 0.82rem;
+}
+
+// ── Symmetric bracket ───────────────────────────────────────────────
+// The two halves of the tournament fan inward toward the Final, NCAA-style.
+// `justify-content: space-around` on each round column does the visual
+// alignment work: with all columns at the same height but with progressively
+// fewer matches, each later-round match naturally centers between its two
+// feeder matches in the previous round.
+
+.bracket-scroll {
+  overflow-x: auto;
+  // Negative margins so the scroll area can bleed to the panel edges
+  // without losing readability on the bracket cards themselves.
+  margin: 0 -8px;
+  padding: 4px 8px 12px;
+}
+
+.bracket {
+  display: flex;
+  align-items: stretch;
+  gap: 14px;
+  min-width: 1280px;
+  // The R32 column needs enough height that its 8 matches don't squish.
+  // Other columns inherit this height and space their matches accordingly.
+  min-height: 580px;
+}
+
+.round {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  min-width: 130px;
+}
+
+.round-r32 {
+  min-width: 140px;
+}
+
+.round-r16 {
+  min-width: 140px;
+}
+
+.round-qf,
+.round-sf {
+  min-width: 145px;
+}
+
+.round-final {
+  min-width: 200px;
+  justify-content: center;
+  gap: 16px;
+}
+
+.round-label {
+  font-size: 0.68rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: $muted;
+  text-align: center;
+  margin-bottom: 6px;
+  font-weight: 600;
+}
+
+.match {
+  background: $bg-2;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 6px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  position: relative;
+  transition:
+    border-color 0.15s ease,
+    transform 0.15s ease;
+
+  &:hover {
+    border-color: rgba(137, 180, 250, 0.25);
+    transform: translateY(-1px);
+  }
+}
+
+.match-final {
+  background: linear-gradient(135deg, rgba(137, 180, 250, 0.08), rgba(166, 227, 161, 0.05));
+  border-color: rgba(137, 180, 250, 0.25);
+  padding: 10px 12px;
+}
+
+.team {
+  display: flex;
+  align-items: center;
+  font-size: 0.82rem;
+  padding: 4px 4px;
+  border-radius: 4px;
+  color: $muted;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+
+  .team-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.team-winner {
+  color: $text;
+  font-weight: 600;
+  position: relative;
+  padding-left: 12px;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 2px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 4px;
+    height: 60%;
+    background: $accent;
+    border-radius: 2px;
+  }
+}
+
+// Champion pill: focal point in the center column under the Final match.
+.champ-pill {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: linear-gradient(135deg, $accent 0%, $accent-2 100%);
+  color: $bg-1;
+  padding: 12px 14px;
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(137, 180, 250, 0.15);
+
+  .trophy {
+    font-size: 28px;
+    width: 28px;
+    height: 28px;
+    color: $bg-1;
+    opacity: 0.85;
+  }
+
+  div {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.15;
+    min-width: 0;
+  }
+
+  .champ-label {
+    font-size: 0.65rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-weight: 700;
+    opacity: 0.75;
+  }
+
+  .champ-name {
+    font-size: 1.05rem;
+    font-weight: 700;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+// ── History chart ────────────────────────────────────────────────────
+.chart-wrapper {
+  position: relative;
+  height: 380px;
+  background: $bg-2;
+  border-radius: 10px;
+  padding: 12px;
+}
+
+// ── Played matches ───────────────────────────────────────────────────
+.matches-day {
+  margin-bottom: 18px;
+}
+
+.day-label {
+  margin: 0 0 8px;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: $muted;
+  font-weight: 600;
+}
+
+.matches-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 8px;
+}
+
+.match-card {
+  background: $bg-2;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 8px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.match-group {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: $accent-3;
+}
+
+.match-teams {
+  font-size: 0.9rem;
+
+  strong {
+    margin: 0 6px;
+    color: $accent;
+    font-weight: 700;
+  }
+}
+
+.empty-msg {
+  color: $muted;
+  text-align: center;
+  padding: 20px;
+}
+
+// ── Bracket: tablet + mobile fallback ────────────────────────────────
+// Below ~900px the 9-column symmetric layout no longer reads cleanly.
+// Flatten to a single column in tournament order: R32 -> R16 -> QF ->
+// SF -> Final. The two halves merge into one section per round; the
+// right-half round label is hidden so the round name appears once.
+//
+// flex `order` is used to interleave left+right halves while keeping
+// the DOM unchanged (avoids duplicating the bracket markup).
+@media (max-width: 900px) {
+  .bracket-scroll {
+    overflow-x: visible;
+    margin: 0;
+    padding: 0;
+  }
+
+  .bracket {
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+    gap: 24px;
+  }
+
+  .round {
+    width: 100%;
+    min-width: 0;
+    justify-content: flex-start;
+    gap: 6px;
+  }
+
+  // Re-order to: R32-L, R32-R, R16-L, R16-R, QF-L, QF-R, SF-L, SF-R, Final
+  // DOM order is:    1L     2L     3L     4L     5F    6R    7R    8R    9R
+  // So we want: 1, 9, 2, 8, 3, 7, 4, 6, 5
+  .round:nth-of-type(1) {
+    order: 1;
+  } // R32 left
+  .round:nth-of-type(9) {
+    order: 2;
+  } // R32 right
+  .round:nth-of-type(2) {
+    order: 3;
+  } // R16 left
+  .round:nth-of-type(8) {
+    order: 4;
+  } // R16 right
+  .round:nth-of-type(3) {
+    order: 5;
+  } // QF left
+  .round:nth-of-type(7) {
+    order: 6;
+  } // QF right
+  .round:nth-of-type(4) {
+    order: 7;
+  } // SF left
+  .round:nth-of-type(6) {
+    order: 8;
+  } // SF right
+  .round:nth-of-type(5) {
+    order: 9;
+  } // Final + champion (climax)
+
+  // Hide the duplicate round label on the right half so each round name
+  // appears exactly once, sitting above all matches of that round.
+  .round:nth-of-type(6) .round-label,
+  .round:nth-of-type(7) .round-label,
+  .round:nth-of-type(8) .round-label,
+  .round:nth-of-type(9) .round-label {
+    display: none;
+  }
+
+  // Tighten the gap between left- and right-half cards of the same round.
+  // Bigger gap kicks in only at the boundary between *different* rounds.
+  .round:nth-of-type(1),  // R32 left
+  .round:nth-of-type(2),  // R16 left
+  .round:nth-of-type(3),  // QF left
+  .round:nth-of-type(4) {
+    // SF left
+    margin-bottom: -16px;
+  }
+
+  // Match cards span the full width with comfortable touch targets.
+  .match {
+    padding: 10px 12px;
+  }
+  .team {
+    font-size: 0.92rem;
+    padding: 6px 6px;
+  }
+  .team-winner {
+    padding-left: 14px;
+    &::before {
+      width: 5px;
+      left: 3px;
+    }
+  }
+  .match-final {
+    padding: 14px;
+  }
+
+  // Champion pill centers + scales down slightly.
+  .champ-pill {
+    margin-top: 8px;
+    padding: 14px 16px;
+    .trophy {
+      font-size: 32px;
+      width: 32px;
+      height: 32px;
+    }
+    .champ-name {
+      font-size: 1.15rem;
+    }
+  }
+}
+
+// ── Page-wide phone niceties ─────────────────────────────────────────
+@media (max-width: 600px) {
+  .wc-page {
+    padding: 16px 12px 48px;
+  }
+  .wc-hero {
+    padding: 20px;
+  }
+  .panel {
+    padding: 16px;
+  }
+  .leaderboard {
+    font-size: 0.8rem;
+    th,
+    td {
+      padding: 6px 8px;
+    }
+  }
+
+  // Bracket section title needs breathing room above the larger mobile cards
+  .bracket-section-title {
+    margin-top: 32px;
+  }
+
+  // On the smallest screens drop the round-label letter-spacing a touch
+  // so longer labels ("Quarter-final") don't wrap.
+  .round-label {
+    font-size: 0.62rem;
+    letter-spacing: 0.08em;
+  }
+}

--- a/src/app/pages/world-cup/world-cup.component.ts
+++ b/src/app/pages/world-cup/world-cup.component.ts
@@ -1,0 +1,276 @@
+import { Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core'
+import { CommonModule, DatePipe, DecimalPipe } from '@angular/common'
+import { RouterModule } from '@angular/router'
+import { MatIconModule } from '@angular/material/icon'
+import { MatTabsModule } from '@angular/material/tabs'
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
+import { Title, Meta } from '@angular/platform-browser'
+import {
+  Chart,
+  LineController,
+  LineElement,
+  PointElement,
+  LinearScale,
+  TimeScale,
+  CategoryScale,
+  Legend,
+  Tooltip,
+} from 'chart.js'
+import { forkJoin } from 'rxjs'
+import {
+  BracketResponse,
+  HistoryResponse,
+  LatestResponse,
+  PlayedMatchesResponse,
+  WorldCupService,
+} from '../../services/world-cup.service'
+
+Chart.register(
+  LineController,
+  LineElement,
+  PointElement,
+  LinearScale,
+  CategoryScale,
+  TimeScale,
+  Legend,
+  Tooltip
+)
+
+// 10-colour palette for the history chart. Repeated if more than 10 teams.
+const PALETTE = [
+  '#89b4fa',
+  '#a6e3a1',
+  '#f9e2af',
+  '#fab387',
+  '#f38ba8',
+  '#cba6f7',
+  '#94e2d5',
+  '#f5c2e7',
+  '#74c7ec',
+  '#eba0ac',
+]
+
+@Component({
+  selector: 'app-world-cup',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterModule,
+    MatIconModule,
+    MatTabsModule,
+    MatProgressSpinnerModule,
+    DatePipe,
+    DecimalPipe,
+  ],
+  templateUrl: './world-cup.component.html',
+  styleUrl: './world-cup.component.scss',
+})
+export class WorldCupComponent implements OnInit, OnDestroy {
+  @ViewChild('historyCanvas') historyCanvas?: ElementRef<HTMLCanvasElement>
+
+  loading = true
+  error: string | null = null
+
+  latest: LatestResponse | null = null
+  bracket: BracketResponse | null = null
+  history: HistoryResponse | null = null
+  playedMatches: PlayedMatchesResponse | null = null
+
+  // Precomputed once when data arrives. Avoids the Angular getter trap
+  // where a property returning a new array on every change-detection
+  // cycle re-renders *ngFor children continuously.
+  groupKeys: string[] = []
+  matchesByDate: { date: string; matches: PlayedMatchesResponse['matches'] }[] = []
+
+  /**
+   * Bracket split into left and right halves so the template can render
+   * a symmetric tournament layout (R32 ─ R16 ─ QF ─ SF │ FINAL │ SF ─ QF ─ R16 ─ R32).
+   */
+  bracketHalves: {
+    left: { r32: string[][]; r16: string[][]; qf: string[][]; sf: string[][] }
+    right: { r32: string[][]; r16: string[][]; qf: string[][]; sf: string[][] }
+  } | null = null
+
+  /**
+   * Teams that won each round = teams that appear in the next round.
+   * Used by the template to bold the winning side of every match.
+   */
+  advancers: {
+    r32: Set<string>
+    r16: Set<string>
+    qf: Set<string>
+    sf: Set<string>
+  } = { r32: new Set(), r16: new Set(), qf: new Set(), sf: new Set() }
+
+  private chart: Chart | null = null
+
+  constructor(
+    private wc: WorldCupService,
+    title: Title,
+    meta: Meta
+  ) {
+    title.setTitle('World Cup 2026 Live Predictions | Bishal Regmi')
+    meta.updateTag({
+      name: 'description',
+      content:
+        'Live calibrated XGBoost + Monte Carlo predictions for the FIFA World Cup 2026. ' +
+        'Updated daily with locked-in group-stage results.',
+    })
+  }
+
+  ngOnInit(): void {
+    forkJoin({
+      latest: this.wc.getLatest({ limit: 48 }),
+      bracket: this.wc.getBracket(),
+      history: this.wc.getHistory({ stage: 'winner' }),
+      played: this.wc.getPlayedMatches(),
+    }).subscribe({
+      next: ({ latest, bracket, history, played }) => {
+        this.latest = latest
+        this.bracket = bracket
+        this.history = history
+        this.playedMatches = played
+
+        // Precompute derived views so templates get stable references.
+        this.groupKeys = Object.keys(bracket.group_winners).sort()
+        this.matchesByDate = this.computeMatchesByDate(played)
+        this.bracketHalves = this.computeBracketHalves(bracket)
+        this.advancers = this.computeAdvancers(bracket)
+
+        this.loading = false
+        // Draw chart on next macrotask so the canvas is in the DOM.
+        setTimeout(() => this.renderHistoryChart())
+      },
+      error: (err) => {
+        this.loading = false
+        this.error =
+          err?.error?.detail ??
+          err?.message ??
+          'Could not load predictions. The backend may still be warming up.'
+      },
+    })
+  }
+
+  ngOnDestroy(): void {
+    this.chart?.destroy()
+  }
+
+  // ── Derived ──────────────────────────────────────────────────────────
+
+  /** Build the left/right halves for a symmetric bracket layout. */
+  private computeBracketHalves(b: BracketResponse) {
+    return {
+      left: {
+        r32: b.r32.slice(0, 8),
+        r16: b.r16.slice(0, 4),
+        qf: b.qf.slice(0, 2),
+        sf: b.sf.slice(0, 1),
+      },
+      right: {
+        r32: b.r32.slice(8),
+        r16: b.r16.slice(4),
+        qf: b.qf.slice(2),
+        sf: b.sf.slice(1),
+      },
+    }
+  }
+
+  /**
+   * A team "advances" from round X if they appear in round X+1.
+   * Building these sets once makes the template-side winner lookup O(1).
+   */
+  private computeAdvancers(b: BracketResponse) {
+    const flat = (pairs: string[][]) => new Set(pairs.flat())
+    return {
+      r32: flat(b.r16),
+      r16: flat(b.qf),
+      qf: flat(b.sf),
+      sf: new Set(b.final_pair),
+    }
+  }
+
+  /** Group played matches by date for the Played tab. Called once. */
+  private computeMatchesByDate(
+    played: PlayedMatchesResponse
+  ): { date: string; matches: PlayedMatchesResponse['matches'] }[] {
+    const groups = new Map<string, PlayedMatchesResponse['matches']>()
+    for (const m of played.matches) {
+      const list = groups.get(m.match_date) ?? []
+      list.push(m)
+      groups.set(m.match_date, list)
+    }
+    return [...groups.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, matches]) => ({ date, matches }))
+  }
+
+  // ── trackBy for template *ngFor stability ────────────────────────────
+  trackByTeam = (_: number, row: { team: string }) => row.team
+  trackByMatch = (_: number, m: PlayedMatchesResponse['matches'][number]) =>
+    `${m.match_date}-${m.home_team}-${m.away_team}`
+  trackByDate = (_: number, d: { date: string }) => d.date
+  trackByPair = (i: number, pair: string[]) => `${i}-${pair[0]}-${pair[1]}`
+  trackByGroup = (_: number, g: string) => g
+
+  // ── Chart ────────────────────────────────────────────────────────────
+
+  private renderHistoryChart(): void {
+    if (!this.history || !this.historyCanvas) return
+
+    const ctx = this.historyCanvas.nativeElement.getContext('2d')
+    if (!ctx) return
+
+    // Build labels = union of all snapshot dates (sorted).
+    const dateSet = new Set<string>()
+    for (const series of this.history.series) {
+      for (const p of series.points) dateSet.add(p.as_of_date)
+    }
+    const labels = [...dateSet].sort()
+
+    const datasets = this.history.series.map((s, i) => {
+      const dateToValue = new Map(s.points.map((p) => [p.as_of_date, p.value]))
+      return {
+        label: s.team,
+        data: labels.map((d) => dateToValue.get(d) ?? null),
+        borderColor: PALETTE[i % PALETTE.length],
+        backgroundColor: PALETTE[i % PALETTE.length],
+        borderWidth: 2,
+        pointRadius: 3,
+        tension: 0.2,
+        spanGaps: true,
+      }
+    })
+
+    this.chart?.destroy()
+    this.chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels, datasets },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: {
+            position: 'bottom',
+            labels: { color: '#cdd6f4', boxWidth: 12, font: { size: 11 } },
+          },
+          tooltip: {
+            callbacks: {
+              label: (ctx) => ` ${ctx.dataset.label}: ${(ctx.raw as number)?.toFixed(2) ?? '-'}%`,
+            },
+          },
+        },
+        scales: {
+          x: {
+            ticks: { color: '#a6adc8', maxRotation: 0 },
+            grid: { color: 'rgba(255,255,255,0.05)' },
+          },
+          y: {
+            ticks: { color: '#a6adc8', callback: (v) => `${v}%` },
+            grid: { color: 'rgba(255,255,255,0.05)' },
+            title: { display: true, text: 'Winner %', color: '#a6adc8' },
+          },
+        },
+      },
+    })
+  }
+}

--- a/src/app/services/world-cup.service.ts
+++ b/src/app/services/world-cup.service.ts
@@ -1,0 +1,116 @@
+import { Injectable } from '@angular/core'
+import { HttpClient, HttpParams } from '@angular/common/http'
+import { Observable } from 'rxjs'
+import { environment } from '../../environments/environment'
+
+// ── Response shapes mirror src/endpoints/worldcup.py in the FastAPI repo. ──
+
+export interface RunMeta {
+  id: number
+  tournament_key: string
+  as_of_date: string // ISO date
+  label: string | null
+  n_simulations: number
+  n_played_matches_locked: number
+  run_timestamp_utc: string
+}
+
+export interface TeamRow {
+  team: string
+  winner_pct: number
+  final_pct: number
+  sf_pct: number
+  qf_pct: number
+  r16_pct: number
+  r32_pct: number
+  elo: number
+}
+
+export interface LatestResponse {
+  run: RunMeta
+  leaderboard: TeamRow[]
+}
+
+export interface BracketResponse {
+  run_id: number
+  as_of_date: string
+  tournament_key: string
+  group_winners: Record<string, string[]>
+  best_thirds: string[]
+  r32: string[][]
+  r16: string[][]
+  qf: string[][]
+  sf: string[][]
+  final_pair: string[]
+  champion: string
+}
+
+export interface HistoryPoint {
+  as_of_date: string
+  label: string | null
+  n_played_matches_locked: number
+  value: number
+}
+
+export interface TeamSeries {
+  team: string
+  points: HistoryPoint[]
+}
+
+export interface HistoryResponse {
+  tournament_key: string
+  stage: string
+  series: TeamSeries[]
+}
+
+export interface PlayedMatch {
+  match_date: string
+  home_team: string
+  away_team: string
+  home_score: number
+  away_score: number
+  group_name: string | null
+}
+
+export interface PlayedMatchesResponse {
+  run: RunMeta
+  matches: PlayedMatch[]
+}
+
+export type HistoryStage = 'winner' | 'final' | 'sf' | 'qf' | 'r16' | 'r32'
+
+@Injectable({ providedIn: 'root' })
+export class WorldCupService {
+  private readonly apiUrl = `${environment.modelApiUrl}/worldcup`
+
+  constructor(private http: HttpClient) {}
+
+  getLatest(opts: { tournament?: string; limit?: number } = {}): Observable<LatestResponse> {
+    let params = new HttpParams()
+    if (opts.tournament) params = params.set('tournament', opts.tournament)
+    if (opts.limit !== undefined) params = params.set('limit', String(opts.limit))
+    return this.http.get<LatestResponse>(`${this.apiUrl}/latest`, { params })
+  }
+
+  getBracket(tournament = '2026'): Observable<BracketResponse> {
+    return this.http.get<BracketResponse>(`${this.apiUrl}/bracket`, {
+      params: new HttpParams().set('tournament', tournament),
+    })
+  }
+
+  getHistory(
+    opts: { tournament?: string; stage?: HistoryStage; teams?: string[] } = {}
+  ): Observable<HistoryResponse> {
+    let params = new HttpParams()
+    if (opts.tournament) params = params.set('tournament', opts.tournament)
+    if (opts.stage) params = params.set('stage', opts.stage)
+    if (opts.teams?.length) params = params.set('teams', opts.teams.join(','))
+    return this.http.get<HistoryResponse>(`${this.apiUrl}/history`, { params })
+  }
+
+  getPlayedMatches(tournament = '2026'): Observable<PlayedMatchesResponse> {
+    return this.http.get<PlayedMatchesResponse>(`${this.apiUrl}/played-matches`, {
+      params: new HttpParams().set('tournament', tournament),
+    })
+  }
+}

--- a/src/app/shared/world-cup-summary/world-cup-summary.component.html
+++ b/src/app/shared/world-cup-summary/world-cup-summary.component.html
@@ -1,0 +1,45 @@
+<section class="wc-summary">
+  <header class="summary-header">
+    <div>
+      <span class="eyebrow">Live Snapshot</span>
+      <h3 class="summary-title">Top 5 by championship probability</h3>
+    </div>
+    <a [routerLink]="['/world-cup']" class="cta">
+      <span>Open full dashboard</span>
+      <mat-icon>arrow_forward</mat-icon>
+    </a>
+  </header>
+
+  <div class="state" *ngIf="loading">
+    <mat-spinner diameter="22"></mat-spinner>
+    <span>Loading latest run...</span>
+  </div>
+
+  <div class="state state-error" *ngIf="error && !loading">
+    <mat-icon>cloud_off</mat-icon>
+    <span>{{ error }}</span>
+  </div>
+
+  <ng-container *ngIf="!loading && !error && data as d">
+    <div class="meta-line">
+      <span
+        >As of <strong>{{ d.run.as_of_date | date: 'mediumDate' }}</strong></span
+      >
+      <span class="dot">·</span>
+      <span>{{ d.run.n_simulations | number }} simulations</span>
+      <span class="dot">·</span>
+      <span>{{ d.run.n_played_matches_locked }} matches locked</span>
+    </div>
+
+    <ol class="top-list">
+      <li *ngFor="let row of d.leaderboard; let i = index">
+        <span class="pos">{{ i + 1 }}</span>
+        <span class="team">{{ row.team }}</span>
+        <span class="bar-wrap">
+          <span class="bar" [style.width.%]="row.winner_pct * 5"></span>
+        </span>
+        <span class="pct">{{ row.winner_pct | number: '1.2-2' }}%</span>
+      </li>
+    </ol>
+  </ng-container>
+</section>

--- a/src/app/shared/world-cup-summary/world-cup-summary.component.scss
+++ b/src/app/shared/world-cup-summary/world-cup-summary.component.scss
@@ -1,0 +1,158 @@
+$bg-2: #181825;
+$bg-3: #1e1e2e;
+$text: #cdd6f4;
+$muted: #a6adc8;
+$accent: #89b4fa;
+$accent-3: #fab387;
+$accent-4: #f38ba8;
+
+.wc-summary {
+  background: $bg-3;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  padding: 20px 22px;
+  color: $text;
+}
+
+.summary-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.eyebrow {
+  display: inline-block;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: $accent;
+  font-weight: 600;
+}
+
+.summary-title {
+  margin: 4px 0 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(137, 180, 250, 0.1);
+  color: $accent;
+  text-decoration: none;
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  transition: background 0.15s ease;
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
+  &:hover {
+    background: rgba(137, 180, 250, 0.18);
+  }
+}
+
+.state {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: $muted;
+  font-size: 0.88rem;
+  padding: 12px 0;
+}
+
+.state-error {
+  color: $accent-4;
+  mat-icon {
+    color: $accent-4;
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+.meta-line {
+  color: $muted;
+  font-size: 0.82rem;
+  margin-bottom: 14px;
+
+  strong {
+    color: $text;
+    font-weight: 600;
+  }
+  .dot {
+    margin: 0 6px;
+    opacity: 0.5;
+  }
+}
+
+.top-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  li {
+    display: grid;
+    grid-template-columns: 22px 130px 1fr 60px;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  .pos {
+    color: $muted;
+    font-size: 0.85rem;
+    font-weight: 500;
+  }
+  .team {
+    font-weight: 600;
+    font-size: 0.92rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .bar-wrap {
+    background: rgba(255, 255, 255, 0.03);
+    height: 8px;
+    border-radius: 4px;
+    overflow: hidden;
+    position: relative;
+  }
+  .bar {
+    display: block;
+    height: 100%;
+    background: linear-gradient(90deg, $accent, $accent-3);
+    border-radius: 4px;
+    max-width: 100%;
+  }
+  .pct {
+    color: $accent;
+    font-weight: 600;
+    font-size: 0.88rem;
+    text-align: right;
+  }
+}
+
+@media (max-width: 560px) {
+  .top-list li {
+    grid-template-columns: 22px 100px 1fr 56px;
+    gap: 8px;
+  }
+}

--- a/src/app/shared/world-cup-summary/world-cup-summary.component.ts
+++ b/src/app/shared/world-cup-summary/world-cup-summary.component.ts
@@ -1,0 +1,47 @@
+import { Component, OnInit } from '@angular/core'
+import { CommonModule, DatePipe, DecimalPipe } from '@angular/common'
+import { RouterModule } from '@angular/router'
+import { MatIconModule } from '@angular/material/icon'
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
+import { LatestResponse, WorldCupService } from '../../services/world-cup.service'
+
+/**
+ * Compact "live snapshot" card embedded on the World Cup project detail page.
+ * Shows the latest run timestamp and the top 5 teams. Links to the full
+ * /world-cup page for the leaderboard, bracket, history chart, and matches.
+ */
+@Component({
+  selector: 'app-world-cup-summary',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    DatePipe,
+    DecimalPipe,
+  ],
+  templateUrl: './world-cup-summary.component.html',
+  styleUrl: './world-cup-summary.component.scss',
+})
+export class WorldCupSummaryComponent implements OnInit {
+  loading = true
+  error: string | null = null
+  data: LatestResponse | null = null
+
+  constructor(private wc: WorldCupService) {}
+
+  ngOnInit(): void {
+    this.wc.getLatest({ limit: 5 }).subscribe({
+      next: (res) => {
+        this.data = res
+        this.loading = false
+      },
+      error: (err) => {
+        this.loading = false
+        this.error =
+          err?.error?.detail ?? err?.message ?? 'Live predictions are temporarily unavailable.'
+      },
+    })
+  }
+}


### PR DESCRIPTION
Wires the World Cup project to its own live dashboard at `/world-cup`, backed by the new `/worldcup/*` FastAPI endpoints (companion PR: regmibishal1/ResearchPortfolio-FastAPI#5).

### What's new

- **`/world-cup` standalone page** with four Material tabs:
  - **Leaderboard** — 48-team table with horizontal win-percentage bars
  - **Bracket** — NCAA-style symmetric layout that fans inward to the Final. Each match highlights the predicted winner; the center column carries a champion pill as the visual climax. Collapses to a single vertical column below 900px so phones get a clean read
  - **History** — Chart.js line chart of championship probability across every archived snapshot
  - **Played** — locked group-stage results grouped by date
- **Compact `<app-world-cup-summary>` card** embedded on the project detail page above About. Driven by a new `Project.liveEmbed` field so other projects can opt in to the same pattern without forking the detail component
- **`WorldCupService`** with typed `HttpClient` calls; `HttpInterceptor` injects `X-API-Key` automatically for any request to `environment.modelApiUrl`
- **`PROJECTS` entry** for `world-cup-prediction` with `status: 'live'` and `demo: '/world-cup'`
- **Route registration** in `app.routes.ts`

### Bracket math

Winner highlighting is derived from data, not a separate API call. For each round, the team that appears in the next round's pair list is marked as having advanced; `O(1)` lookup via precomputed `Set`s built once in `ngOnInit`.

### Performance notes

The first cut had an Angular getter trap — `matchesByDate` and `groupKeys` were computed properties returning new arrays on every change-detection cycle, which froze the browser on the Played tab. Both now precompute once in the subscribe callback so templates read stable references. Every `*ngFor` carries a `trackBy` for good measure.

### Test plan

- [x] `yarn build` passes with no type errors
- [x] `/world-cup` route loads against the local Docker FastAPI; leaderboard / bracket / history / played all render
- [x] `/project/world-cup-prediction` shows the summary card above About; the existing "Demo" button routes to `/world-cup`
- [x] Bracket layout: predicted winner highlighted in every match, champion pill in center column
- [x] Mobile viewport (Chrome DevTools, iPhone 14 / 390px): bracket flattens to vertical column, single round label per round, champion at the bottom
- [x] Played tab no longer freezes (73 matches render instantly)
- [x] History chart shows multiple snapshots' worth of data
- [x] No em-dashes / ellipses / curly quotes in the new user-facing text